### PR TITLE
Fix using subscription in container

### DIFF
--- a/4.0/Dockerfile.rhel7
+++ b/4.0/Dockerfile.rhel7
@@ -20,7 +20,10 @@ LABEL BZComponent="rh-passenger40-docker" \
       Release="33.3" \
       Architecture="x86_64"
 
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# To use subscription inside container yum command has to be run first (before yum-config-manager)
+# https://access.redhat.com/solutions/1443553
+RUN yum repolist > /dev/null && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     INSTALL_PKGS="rh-ruby22 rh-ruby22-ruby-devel rh-ruby22-rubygem-rake v8314 rh-ruby22-rubygem-bundler rh-ror41-rubygem-rack nodejs010 rh-passenger40-mod_passenger rh-passenger40-ruby22 httpd24" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \


### PR DESCRIPTION
Enabling host repositories didn't work with docker 1.10 and newer inside OpenStack. It was fixed in latest rhel7 base release, so using 'rhel7' base image is required for RHEL CI. Postgresql PR - sclorg/postgresql-container#150

Also to enable repositories inside container running 'yum' first is required - see https://access.redhat.com/solutions/1443553 . Similar to sclorg/s2i-base-container#99 .


@hhorak @bparees Please take a look and merge.