### PR TITLE
Use centos/ namespaced s2i base image

### DIFF
--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/base-centos7
+FROM centos/s2i-base-centos7
 
 # This image provides a Passenger 4.0 environment you can use to run your Passenger
 # applications.


### PR DESCRIPTION
For centos/ namespaced images use centos/ namespaced s2i base image. This image is based on https://github.com/sclorg/s2i-base-container/ and is built by coreservices-jenkins maintained by RHSCL team.

@hhorak @bparees Please take a look and merge.