### PR TITLE
Update Dockerfiles

### DIFF
--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -17,7 +17,7 @@ assets compilation."
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
-      io.k8s.description="DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="Passenger 4.0" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,passenger,ruby,nodejs" \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -5,13 +5,20 @@ FROM centos/s2i-base-centos7
 
 EXPOSE 8080
 
-ENV PASSENGER_VERSION 4.0
+ENV PASSENGER_VERSION 4.0 \
+    SUMMARY="Passenger 4.0 environment you can use to run your Passenger" \
+    DESCRIPTION="Passenger 4.0 environment you can use to run your Passenger"
 
-LABEL summary="Passenger 4.0 environment you can use to run your Passenger" \
-      io.k8s.description="Passenger 4.0 environment you can use to run your Passenger" \
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="DESCRIPTION" \
       io.k8s.display-name="Passenger 4.0" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,passenger,ruby,nodejs"
+      io.openshift.tags="builder,passenger,ruby,nodejs" \
+      com.redhat.component="rh-passenger40-docker" \
+      name="centos/passenger-40-centos7" \
+      version="4.0" \
+      release="1"
 
 RUN yum install -y centos-release-scl-rh && \
     INSTALL_PKGS="rh-ruby22 rh-ruby22-ruby-devel rh-ruby22-rubygem-rake v8314 rh-ruby22-rubygem-bundler rh-ror41-rubygem-rack nodejs010 rh-passenger40-mod_passenger rh-passenger40-ruby22 httpd24 nss_wrapper" && \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -5,9 +5,15 @@ FROM centos/s2i-base-centos7
 
 EXPOSE 8080
 
-ENV PASSENGER_VERSION 4.0 \
-    SUMMARY="Passenger 4.0 environment you can use to run your Passenger" \
-    DESCRIPTION="Passenger 4.0 environment you can use to run your Passenger"
+ENV PASSENGER_VERSION=4.0 \
+    RUBY_VERSION=2.2 \
+    NODEJS_VERSION=0.10
+
+ENV SUMMARY="Phusion Passenger $PASSENGER_VERSION web server and application server" \
+    DESCRIPTION="Phusion Passenger $PASSENGER_VERSION web server and application server configured \
+with Apache httpd web server. It also provides a Ruby $RUBY_VERSION platform for \
+building and running applications. Node.js $NODEJS_VERSION is preinstalled for \
+assets compilation."
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \

--- a/4.0/Dockerfile.rhel7
+++ b/4.0/Dockerfile.rhel7
@@ -5,9 +5,15 @@ FROM rhscl/s2i-base-rhel7:1
 
 EXPOSE 8080
 
-ENV PASSENGER_VERSION 4.0 \
-    SUMMARY="Passenger 4.0 environment you can use to run your Passenger" \
-    DESCRIPTION="Passenger 4.0 environment you can use to run your Passenger"
+ENV PASSENGER_VERSION=4.0 \
+    RUBY_VERSION=2.2 \
+    NODEJS_VERSION=0.10
+
+ENV SUMMARY="Phusion Passenger $PASSENGER_VERSION web server and application server" \
+    DESCRIPTION="Phusion Passenger $PASSENGER_VERSION web server and application server configured \
+with Apache httpd web server. It also provides a Ruby $RUBY_VERSION platform for \
+building and running applications. Node.js $NODEJS_VERSION is preinstalled for \
+assets compilation."
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \

--- a/4.0/Dockerfile.rhel7
+++ b/4.0/Dockerfile.rhel7
@@ -17,7 +17,7 @@ assets compilation."
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
-      io.k8s.description="DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="Passenger 4.0" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,passenger,ruby,nodejs" \

--- a/4.0/Dockerfile.rhel7
+++ b/4.0/Dockerfile.rhel7
@@ -5,20 +5,20 @@ FROM rhscl/s2i-base-rhel7:1
 
 EXPOSE 8080
 
-ENV PASSENGER_VERSION 4.0
+ENV PASSENGER_VERSION 4.0 \
+    SUMMARY="Passenger 4.0 environment you can use to run your Passenger" \
+    DESCRIPTION="Passenger 4.0 environment you can use to run your Passenger"
 
-LABEL summary="Passenger 4.0 environment you can use to run your Passenger" \
-      io.k8s.description="Passenger 4.0 environment you can use to run your Passenger" \
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="DESCRIPTION" \
       io.k8s.display-name="Passenger 4.0" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,passenger,ruby,nodejs"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-passenger40-docker" \
+      io.openshift.tags="builder,passenger,ruby,nodejs" \
+      com.redhat.component="rh-passenger40-docker" \
       name="rhscl/passenger-40-rhel7" \
       version="4.0" \
-      release="33.3" \
-      architecture="x86_64"
+      release="33.3"
 
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553


### PR DESCRIPTION
Provide same labels for all base image variants (CentOS, RHEL, Fedora)
    - add name, version, summary and description labels
    - remove architecture label for RHEL based images (this label is set in RHE$

(don't use separate instruction for each label)

@jorton Any suggestions about values of summary and description?

@hhorak @praiskup @pkubatrh Please take a look and merge.