### PR TITLE
Refactoring the image so Fedora variant can use the same sources

### DIFF
--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -18,12 +18,12 @@ assets compilation."
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$DESCRIPTION" \
-      io.k8s.display-name="Passenger 4.0" \
+      io.k8s.display-name="Passenger $PASSENGER_VERSION" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,passenger,ruby,nodejs" \
       com.redhat.component="rh-passenger40-docker" \
       name="centos/passenger-40-centos7" \
-      version="4.0" \
+      version="$PASSENGER_VERSION" \
       release="1"
 
 RUN yum install -y centos-release-scl-rh && \
@@ -38,20 +38,16 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY ./root/ /
 
-RUN chown -R 1001:0 /opt/app-root
+ENV PASSENGER_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/passenger/ \
+    PASSENGER_APP_ROOT=/opt/app-root \
+    PASSENGER_VAR_RUN=/var/run/rh-passenger40 \
+    PASSENGER_SESSION_DIR=/tmp/sessions \
+    PASSENGER_RUBY_BIN=/opt/rh/rh-passenger40/root/usr/libexec/passenger-ruby22 \
+    HTTPD_CONFIGURATION_PATH=/opt/rh/httpd24/root/etc/httpd/conf/httpd.conf \
+    HTTPD_VAR_RUN=/opt/rh/httpd24/root/var/run/httpd \
+    HTTPD_VAR_ORIG_PATH=/opt/rh/httpd24/root/var
 
-# In order to drop the root user, we have to make some directories world
-# writeable as OpenShift default "security" model is to run the container under
-# random UID.
-#    sed -ri ' s!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g; s!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g;' /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
-RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
-    head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
-    mkdir /tmp/sessions && \
-    mkdir -p /opt/app-root/src/public && \
-    chmod -R og+rwx /opt/rh/httpd24/root/var/run/httpd && \
-    chmod -R og+rwx /var/run/rh-passenger40 && \
-    chown -R 1001:0 /opt/app-root /tmp/sessions && \
-    cat /opt/app-root/etc/passenger.conf >> /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf
+RUN /usr/libexec/passenger-prepare
 
 USER 1001
 

--- a/4.0/Dockerfile.rhel7
+++ b/4.0/Dockerfile.rhel7
@@ -18,12 +18,12 @@ assets compilation."
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$DESCRIPTION" \
-      io.k8s.display-name="Passenger 4.0" \
+      io.k8s.display-name="Passenger $PASSENGER_VERSION" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,passenger,ruby,nodejs" \
       com.redhat.component="rh-passenger40-docker" \
       name="rhscl/passenger-40-rhel7" \
-      version="4.0" \
+      version="$PASSENGER_VERSION" \
       release="33.3"
 
 # We need to call 2 (!) yum commands before being able to enable repositories properly
@@ -45,20 +45,16 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY ./root/ /
 
-RUN chown -R 1001:0 /opt/app-root
+ENV PASSENGER_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/passenger/ \
+    PASSENGER_APP_ROOT=/opt/app-root \
+    PASSENGER_VAR_RUN=/var/run/rh-passenger40 \
+    PASSENGER_SESSION_DIR=/tmp/sessions \
+    PASSENGER_RUBY_BIN=/opt/rh/rh-passenger40/root/usr/libexec/passenger-ruby22 \
+    HTTPD_CONFIGURATION_PATH=/opt/rh/httpd24/root/etc/httpd/conf/httpd.conf \
+    HTTPD_VAR_RUN=/opt/rh/httpd24/root/var/run/httpd \
+    HTTPD_VAR_ORIG_PATH=/opt/rh/httpd24/root/var
 
-# In order to drop the root user, we have to make some directories world
-# writeable as OpenShift default "security" model is to run the container under
-# random UID.
-#    sed -ri ' s!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g; s!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g;' /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
-RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
-    head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
-    mkdir /tmp/sessions && \
-    mkdir -p /opt/app-root/src/public && \
-    chmod -R og+rwx /opt/rh/httpd24/root/var/run/httpd && \
-    chmod -R og+rwx /var/run/rh-passenger40 && \
-    chown -R 1001:0 /opt/app-root /tmp/sessions && \
-    cat /opt/app-root/etc/passenger.conf >> /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf
+RUN /usr/libexec/passenger-prepare
 
 USER 1001
 

--- a/4.0/root/opt/app-root/etc/httpdconf.sed
+++ b/4.0/root/opt/app-root/etc/httpdconf.sed
@@ -1,9 +1,0 @@
-s/^Listen 80/Listen 0.0.0.0:8080/
-s/^User apache/User default/
-s/^Group apache/Group root/
-s%^DocumentRoot "/opt/rh/httpd24/root/var/www/html"%DocumentRoot "/opt/app-root/src/public"%
-s%^<Directory "/opt/rh/httpd24/root/var/www/html"%<Directory "/opt/app-root/src"%
-s%^<Directory "/opt/rh/httpd24/root/var/html"%<Directory "/opt/app-root/src"%
-s%^ErrorLog "logs/error_log"%ErrorLog "/tmp/error_log"%
-s%CustomLog "logs/access_log"%CustomLog "/tmp/access_log"%
-151s%AllowOverride None%AllowOverride All%

--- a/4.0/root/opt/app-root/etc/passenger.conf
+++ b/4.0/root/opt/app-root/etc/passenger.conf
@@ -1,11 +1,11 @@
-PassengerRuby /opt/rh/rh-passenger40/root/usr/libexec/passenger-ruby22
+PassengerRuby /usr/bin/ruby
 # We are running as non-root, so turn of user switching
 PassengerUserSwitching off
 PassengerDefaultUser default
 PassengerDefaultGroup root
 
 <VirtualHost *:8080>
-    PassengerRuby /opt/rh/rh-passenger40/root/usr/libexec/passenger-ruby22
+    PassengerRuby /usr/bin/ruby
     PassengerEnabled on
     ServerName localhost
     # Be sure to point to 'public'!

--- a/4.0/root/usr/libexec/passenger-prepare
+++ b/4.0/root/usr/libexec/passenger-prepare
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -xe
+
+sed -i -e "s/^Listen 80/Listen 0.0.0.0:8080/" ${HTTPD_CONFIGURATION_PATH}
+sed -i -e "s/^User apache/User default/" ${HTTPD_CONFIGURATION_PATH}
+sed -i -e "s/^Group apache/Group root/" ${HTTPD_CONFIGURATION_PATH}
+sed -i -e "s%^DocumentRoot \"${HTTPD_VAR_ORIG_PATH}/www/html\"%DocumentRoot \"${PASSENGER_APP_ROOT}/src/public\"%" ${HTTPD_CONFIGURATION_PATH}
+sed -i -e "s%^<Directory \"${HTTPD_VAR_ORIG_PATH}/www/html\"%<Directory \"${PASSENGER_APP_ROOT}/src\"%" ${HTTPD_CONFIGURATION_PATH}
+sed -i -e "s%^<Directory \"${HTTPD_VAR_ORIG_PATH}/html\"%<Directory \"${PASSENGER_APP_ROOT}/src\"%" ${HTTPD_CONFIGURATION_PATH}
+sed -i -e "s%^ErrorLog \"logs/error_log\"%ErrorLog \"/tmp/error_log\"%" ${HTTPD_CONFIGURATION_PATH}
+sed -i -e "s%CustomLog \"logs/access_log\"%CustomLog \"/tmp/access_log\"%" ${HTTPD_CONFIGURATION_PATH}
+
+sed -i -e "151s%AllowOverride None%AllowOverride All%" ${HTTPD_CONFIGURATION_PATH}
+head -n151 ${HTTPD_CONFIGURATION_PATH} | tail -n1 | grep "AllowOverride All" || exit 1
+
+sed -i -e "s%/usr/bin/ruby%${PASSENGER_RUBY_BIN}%" ${PASSENGER_APP_ROOT}/etc/passenger.conf
+
+mkdir ${PASSENGER_SESSION_DIR}
+mkdir -p ${PASSENGER_APP_ROOT}/src/public
+chmod -R og+rwx ${HTTPD_VAR_RUN}
+chmod -R og+rwx ${PASSENGER_VAR_RUN}
+chown -R 1001:0 ${PASSENGER_APP_ROOT} ${PASSENGER_SESSION_DIR}
+cat ${PASSENGER_APP_ROOT}/etc/passenger.conf >> ${HTTPD_CONFIGURATION_PATH}
+chown -R 1001:0 ${PASSENGER_APP_ROOT}
+

--- a/4.0/test/run
+++ b/4.0/test/run
@@ -111,12 +111,16 @@ test_connection() {
   local sleep_time=1
   local attempt=1
   local result=1
+  local tmpout=$(mktemp /tmp/test-passenger-XXXXXX)
   while [ $attempt -le $max_attempts ]; do
-    response_code=$(curl -s -w %{http_code} -o /dev/null http://$(container_ip):${test_port}/)
+    response_code=$(curl -s -w %{http_code} -o ${tmpout} http://$(container_ip):${test_port}/)
     status=$?
     if [ $status -eq 0 ]; then
       if [ $response_code -eq 200 ]; then
         result=0
+      else
+	echo "ERROR[curl] got response_code $response_code, out is:"
+	cat ${tmpout}
       fi
       break
     fi
@@ -197,7 +201,7 @@ for server in ${WEB_SERVERS[@]}; do
   test_connection
   check_result $?
 
-  test_scl_usage "ruby --version" "ruby 2.2.2"
+  test_scl_usage "ruby --version" "ruby 2."
   check_result $?
 
   info "All tests for the ${server}-test-app finished successfully."


### PR DESCRIPTION
This change moves image preparation into a separate file and sed config was replaced by several sed commands, so we can use environment variables defined in the Dockerfile.