### PR TITLE
Fix location of s2i scripts in atomic-install.sh

### DIFF
--- a/4.0/atomic-contrib/usr/bin/atomic-install.sh
+++ b/4.0/atomic-contrib/usr/bin/atomic-install.sh
@@ -3,18 +3,18 @@
 # Assemble the STI application.
 # Mount the application into /tmp/src, run assemble and create
 # the new image with the changes done by assemble
-ID=$(chroot "${HOST}" /usr/bin/docker run -v "${OPT1}:/tmp/src:Z" -d "${IMAGE}" /usr/local/sti/assemble)
+ID=$(chroot "${HOST}" /usr/bin/docker run -v "${OPT1}:/tmp/src:Z" -d "${IMAGE}" /usr/libexec/s2i/assemble)
 chroot "${HOST}" /usr/bin/docker wait $ID
 chroot "${HOST}" /usr/bin/docker logs $ID
 chroot "${HOST}" /usr/bin/docker commit $ID "${NAME}"
 chroot "${HOST}" /usr/bin/docker stop $ID
 chroot "${HOST}" /usr/bin/docker rm $ID
 
-# 'docker commit' changes the CMD to /usr/local/sti/assemble,
+# 'docker commit' changes the CMD to /usr/libexec/s2i/assemble,
 # so rebuild the image with proper CMD to set it back.
 chroot "${HOST}" /usr/bin/docker build -t "${NAME}" - <<EOF >/dev/null 2>&1
 FROM ${NAME}
-CMD ["/usr/local/sti/run"]
+CMD ["/usr/libexec/s2i/run"]
 EOF
 
 # Create the docker container so we can later start using systemd


### PR DESCRIPTION
I've been going through s2i containers for mentions of the "sti" directory, which has been replaced by "s2i", and I've found this old script.

I believe the location is old, so I fixed with the new. However, I don't know how to properly test this, so I'd appreciate a review.